### PR TITLE
Cambio enlaces a recursos (fuentes, js, etc.) a HTTPS

### DIFF
--- a/salarios.html
+++ b/salarios.html
@@ -15,8 +15,8 @@
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/font-awesome.min.css" rel="stylesheet">
     <!-- Google Font -->
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Ubuntu:700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Ubuntu:700' rel='stylesheet' type='text/css'>
     
 
     <!-- Table Sorter -->
@@ -246,8 +246,8 @@
      <script type="text/javascript" src="js/jquery.tablesorter.min.js"></script> 
      
      <!-- highcharts.js -->
-     <script src="http://code.highcharts.com/highcharts.js"></script>
-     <script type="text/javascript" src="http://code.highcharts.com/modules/data.js"></script>
+     <script src="https://code.highcharts.com/highcharts.js"></script>
+     <script type="text/javascript" src="https://code.highcharts.com/modules/data.js"></script>
      
      <!-- isotope -->
      <script src="js/isotope.pkgd.js"></script>


### PR DESCRIPTION
Al usar SSL en el despliegue en el servidor se hace necesario utilizar siempre HTTPS para recoger recursos externos. Además es mas seguro y puede permitir que no haya problemas de men-in-the-middle y cosas por el estilo.
